### PR TITLE
Avoid syslog spam from getting sensor readings via ipmitool

### DIFF
--- a/templates/sudo_collectd_ipmitool
+++ b/templates/sudo_collectd_ipmitool
@@ -1,3 +1,3 @@
 # {{ ansible_managed }}
-Defaults:nobody !requiretty
+Defaults:nobody !requiretty, !syslog
 nobody ALL=NOPASSWD: /usr/bin/ipmitool


### PR DESCRIPTION
Seems every node runs this once per minute, leading to quite a lot of spam in the central syslogs.
