### PR TITLE
Provide power consumption and inlet temp on heterogeneous systems

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -32,6 +32,18 @@
     yum: name=ipmitool state=present
     when: ansible_virtualization_role != "guest" and collectd_ipmitool
 
+  - name: install dcmi.sh on non guest hosts
+    get_url: owner=nobody group=nobody mode=0755 backup=no url=https://github.com/jabl/collectd-plugin-dcmi/blob/v1.0.1/dcmi.sh dest=/usr/local/sbin/dcmi.sh
+    when: ansible_virtualization_role != "guest" and collectd_ipmitool
+
+  - name: add sudoers rule for freeipmi
+    template: src=sudo_collectd_freeipmi dest=/etc/sudoers.d/sudo_collectd_freeipmi owner=root group=root mode=0640
+    when: ansible_virtualization_role != "guest" and collectd_ipmitool
+
+  - name: install freeipmi if virtualization role is not guest
+    yum: name=freeipmi state=present
+    when: ansible_virtualization_role != "guest" and collectd_ipmitool
+
   - name: drop some collectd excessive message by rsyslog
     template: src=collectd_rsyslog_drop.conf dest=/etc/rsyslog.d/10_collectd_drop.conf owner=root mode=0644 backup=no
     register: collectd_rsyslog_drop

--- a/templates/collectd.conf.j2
+++ b/templates/collectd.conf.j2
@@ -95,6 +95,7 @@ LoadPlugin network
 # If not a VM
 <Plugin exec>
 	Exec "nobody" "/usr/local/bin/ipmitool.sh"
+	Exec "nobody" "/usr/local/sbin/dcmi.sh"
 </Plugin>
     {% endif %}
   {% endif %}

--- a/templates/sudo_collectd_freeipmi
+++ b/templates/sudo_collectd_freeipmi
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+Defaults:nobody !requiretty, !syslog
+nobody ALL=NOPASSWD: /usr/sbin/ipmi-dcmi
+nobody ALL=NOPASSWD: /usr/sbin/ipmi-sensors


### PR DESCRIPTION
Using DCMI we can get power consumption on all our nodes (HP G6, G7,
Gen8, Dell PE Haswell). Also do some munging so we get the inlet air
temperature on all the systems with a consistent metric name.
