### PR TITLE
Added options for more prefix mangling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,10 +18,34 @@ collectd_drop_rsyslog_spam: False
 # set collectd_force_geturl to True to set force=true with the get_url module. This re-downloads the external scripts. If False it only downloads the file if it doesn't exist at all.
 collectd_force_geturl: False
 collectd_precache: True
-collectd_set_graphite_prefix: False
-# escape backslashes with backslashes
-collectd_graphite_prefix_1: "^hpc\\.clustername\\."
-collectd_graphite_prefix_2: "hpc.clustername."
+
+# Extra rules for collectd prefix mangling
+collectd_prefix_rules: []
+
+# Example: This mimics the old behaviour if you had
+# collectd_set_graphite_prefix: True
+#
+# collectd_prefix_rules:
+#   - name: generic_prefix
+#     regexp: "^hpc\\.clustername\\."
+#     invert_match: True
+#     prefix: "hpc.clustername."
+#     stop: False
+#
+# This is similar, but puts storage* servers in their own prefix.
+#
+# collectd_prefix_rules:
+#   - name: "storage_prefix"
+#     regexp: "^storage"
+#     invert_match: False
+#     prefix: "hpc.storage."
+#     stop: True
+#   - name: generic_prefix
+#     regexp: "^hpc\\.clustername\\."
+#     invert_match: True
+#     prefix: "hpc.clustername."
+#     stop: False
+# if stop is True, no other prefix rules will be processed after this.
 
 # Aggregation plugin
 collectd_plugins_aggregation:

--- a/templates/collectd.conf.j2
+++ b/templates/collectd.conf.j2
@@ -124,14 +124,15 @@ LoadPlugin target_replace
 
 {% if collectd_precache == true %}
 PreCacheChain "PreCache"
-{% if collectd_set_graphite_prefix %}
+{% if collectd_prefix_rules %}
 <Chain "PreCache">
-    # Replace dots in FQDN and prepend a Graphite prefix to the hostname.
-    <Rule "set_graphite_prefix">
+{% for rule in collectd_prefix_rules %}
+    <Rule "{{ rule.name }}">
         <Match "regex">
-            # Avoid adding the prefix a second time for local aggregated data.
-            Host "{{ collectd_graphite_prefix_1 }}"
+            Host "{{ rule.regexp }}"
+{% if rule.invert_match %}
             Invert true
+{% endif %}
         </Match>
         <Target "replace">
         # No global replace available, so we need to run same regex multiple times.
@@ -139,9 +140,14 @@ PreCacheChain "PreCache"
         Host "\\." "_"
         Host "\\." "_"
         Host "\\." "_"
-        Host "^" "{{ collectd_graphite_prefix_2 }}"
+        Host "^" "{{ rule.prefix }}"
         </Target>
+{% if rule.stop %}
+        <Target "return">
+        </Target>
+{% endif %}
     </Rule>
+{% endfor %}
 </Chain>
 {% endif %}
 


### PR DESCRIPTION
Now you can specify more prefix handling if you don't e.g. want the same
prefix for all hosts going through this collector.

NOTE: The default behaviour stays the same, but if you are using
prefixes you *will* need to update your configuration data.