### PR TITLE
Modernize travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
 
-sudo: required
-dist: trusty
-group: edge
-
 services:
   - docker
 


### PR DESCRIPTION
Trusty has been deprecated, use the default (xenial at the
moment). Similarly, sudo is always available as the travis
container-based infrastructure has been deprecated. Finally, group tag
isn't necessary anymore either.